### PR TITLE
Fix discord.js, add a regex to ignore ANSI, change code lines to code blocks

### DIFF
--- a/bridge/messageBucket.js
+++ b/bridge/messageBucket.js
@@ -32,6 +32,7 @@ Bucket.prototype.enable = function(channel) {
 Bucket.prototype.update = function () {
     if(this._enabled && this._messages.length > 0) {
         var str = this._messages.join('\n')
+        str = str.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/ig, '')
 
         if(this._monospace) str = '```' + str + '```'
         this._channel.send(str, {split: true}) // split just in case

--- a/bridge/messageBucket.js
+++ b/bridge/messageBucket.js
@@ -33,7 +33,7 @@ Bucket.prototype.update = function () {
     if(this._enabled && this._messages.length > 0) {
         var str = this._messages.join('\n')
 
-        if(this._monospace) str = '`' + str + '`'
+        if(this._monospace) str = '```' + str + '```'
         this._channel.send(str, {split: true}) // split just in case
 
         this.clear()

--- a/clients/discord.js
+++ b/clients/discord.js
@@ -8,8 +8,8 @@ const client = new Discord.Client({
 
 client.on('ready', () => {
     console.log(`[discord] Logged in as ${client.user.tag}.`);
-    client._chat = client.channels.get(client._config.channels.chat) 
-    client._log  = client.channels.get(client._config.channels.log)
+    client._chat = client.channels.get(client._config.channels.cache.chat) 
+    client._log  = client.channels.get(client._config.channels.cache.log)
 });
 
 client.on('error', (err) => {


### PR DESCRIPTION
This pull request addresses a few things, the most important of which being making the thing work. It also adds a regex to ignore ANSI stuff in messages and switches the messages from `code lines` to ```code blocks``` (they look the same on Github). Thank you for making this wonderful software, it's very handy.